### PR TITLE
Fix shebang

### DIFF
--- a/lorem
+++ b/lorem
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
* Use the environment so that people can run this script in a virtual environment if they choose
* Since this is strictly Python 2, use the `python2` executable for systems whose default Python is 3.