### PR TITLE
Added support for no line returns.

### DIFF
--- a/lorem
+++ b/lorem
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """

--- a/lorem
+++ b/lorem
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """

--- a/lorem
+++ b/lorem
@@ -376,7 +376,7 @@ def parse_args(arguments=None):
     parser.add_argument('-t', action='store_true',
                         help='run self-tests and exit')
     parser.add_argument('--cols', action='store', type=int, metavar='COLS',
-                        help='override line width - default 80 (set to 0 for no line returns)')
+                        default=80, help='override line width - default 80 (set to 0 for no line returns)')
 
     ogroup = parser.add_argument_group('output format (mutually exclusive)')
     ogroup.add_argument('--words', '-n', action='store', type=int, metavar='N',

--- a/lorem
+++ b/lorem
@@ -376,7 +376,7 @@ def parse_args(arguments=None):
     parser.add_argument('-t', action='store_true',
                         help='run self-tests and exit')
     parser.add_argument('--cols', action='store', type=int, metavar='COLS',
-                        default=80, help='override line width - default 80')
+                        help='override line width - default 80 (set to 0 for no line returns)')
 
     ogroup = parser.add_argument_group('output format (mutually exclusive)')
     ogroup.add_argument('--words', '-n', action='store', type=int, metavar='N',
@@ -571,7 +571,11 @@ def do_lorem(opt):
     if opt.randomize:
         lorem = randomize(lorem)
 
-    lorem = fill(lorem, width=opt.cols)
+    if opt.cols == 0:
+        lorem = fill(lorem, width=80)
+        lorem = no_linebreaks(lorem)
+    else:
+        lorem = fill(lorem, width=opt.cols)
 
     if opt.sentences is not None:
         lorem = get_sentences(lorem, opt.sentences)
@@ -583,7 +587,11 @@ def do_lorem(opt):
         lorem = get_lines(lorem, opt.lines)
 
     if opt.lines is None and opt.chars is None:
-        lorem = fill(lorem, width=opt.cols)
+        if opt.cols == 0:
+            lorem = fill(lorem, width=80)
+            lorem = no_linebreaks(lorem)
+        else: 
+            lorem = fill(lorem, width=opt.cols)
 
     return do_case(lorem, opt.case)
 

--- a/sanitycheck.sh
+++ b/sanitycheck.sh
@@ -47,6 +47,16 @@ else
 fi
 testcases=$((testcases+1))
 
+action="lorem --cols 0 --words 16"
+if [ "`$action`" == *"\n"* ]
+then
+    echo BROKEN: $action
+    broken=$((broken+1))
+else
+    echo OK: $action
+fi
+testcases=$((testcases+1))
+
 for random in "" "--randomize" "--cols 20" "--cols 160 --randomize"
 do
     for lorem in lorem decameron faust fleurs spook strindberg \


### PR DESCRIPTION
## No-Newline Option

I have added the option to have no line returns when using the flag `--cols 0`. This option is useful when generating text for software that soft-wraps text for the user automatically (i.e. things not on the command line) or has issues with new line characters (common in bloated old webapps).

## Known issues

- When generating per line, using `--cols 0` returns the source material repeated `--line` number of times. I didn't fix this because there's no reason a user would try to generate text by line but with no line return except to see what happens.